### PR TITLE
Failing Consumer

### DIFF
--- a/src/main/java/com/zecops/example/ExampleController.java
+++ b/src/main/java/com/zecops/example/ExampleController.java
@@ -1,6 +1,8 @@
 package com.zecops.example;
 
+import com.zecops.example.dto.FailingMessage;
 import com.zecops.example.dto.Greeting;
+import com.zecops.example.dto.Upload;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -80,6 +82,13 @@ public class ExampleController {
         }
         return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).build();
     }
+
+    @PostMapping("generateFailingMessage")
+    public ResponseEntity<?> generateFailingMessage(@RequestParam("key") String key, @RequestParam("failCount") int failCount) {
+        kafkaTemplate.send("failing-messages", key, new FailingMessage(failCount));
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
+    }
+
 
     @PostMapping("resetVerifier")
     public ResponseEntity<?> resetVerifier() {

--- a/src/main/java/com/zecops/example/FailingConsumer.java
+++ b/src/main/java/com/zecops/example/FailingConsumer.java
@@ -1,0 +1,54 @@
+package com.zecops.example;
+
+import com.zecops.example.dto.FailingMessage;
+import com.zecops.example.dto.Greeting;
+import com.zecops.example.dto.Upload;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+@Component
+public class FailingConsumer {
+
+    private ConcurrentHashMap<String, Integer> expectedFailCount = new ConcurrentHashMap<>();
+
+    @Transactional
+    @KafkaListener(topics = "failing-messages", groupId = "failing-consumer", containerFactory = "kafkaListenerContainerFactoryForUploads", clientIdPrefix = "${spring.kafka.client-id}-failing-consumer")
+    public void processUploads(@Payload FailingMessage failingMessage,
+                               @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+                               @Header(KafkaHeaders.RECEIVED_KEY) String key,
+                               @Header(KafkaHeaders.OFFSET) int offset) {
+        log.info("Received Upload key: " + key);
+        Integer newVal = expectedFailCount.compute(key, (k, v) -> {
+            if (v == null || v == -1) {
+                log.info("The total requested fail count is set to " + failingMessage.getFailCount());
+                return failingMessage.getFailCount()-1;
+            }
+            else {
+                if (v > 0)
+                    log.info("This message will fail now and then " + (v-1) + " more times.");
+                return v - 1;
+            }
+        });
+        if (newVal < 0) {
+            log.info("Successfully processed Upload key: " + key);
+        } else {
+            log.info("Simulating error for key: " + key);
+            throw new RuntimeException("Simulated failure of Upload in FailingConsumer for key: " + key);
+        }
+    }
+}

--- a/src/main/java/com/zecops/example/KafkaConsumerConfig.java
+++ b/src/main/java/com/zecops/example/KafkaConsumerConfig.java
@@ -14,7 +14,9 @@ import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.apache.kafka.common.serialization.*;
 import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.util.backoff.FixedBackOff;
 
 import java.util.HashMap;
 import java.util.Locale;

--- a/src/main/java/com/zecops/example/dto/FailingMessage.java
+++ b/src/main/java/com/zecops/example/dto/FailingMessage.java
@@ -1,0 +1,12 @@
+package com.zecops.example.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FailingMessage {
+    private int failCount;
+}


### PR DESCRIPTION
With this code, you can use the following API to send a message that will fail predetermined count of times:
```
POST http://localhost:1080/generateFailingMessage?key=failingmessage&failCount=10
```
When `failCount` is set to number higher than 9 the consumer offset is pushed. You can see that in the logs: 

```
2025-05-21T13:11:04.703+02:00 ERROR 78874 --- [org.springframework.kafka.KafkaListenerEndpointContainer#1-0-C-1] o.s.kafka.listener.DefaultErrorHandler   : Backoff FixedBackOff{interval=0, currentAttempts=10, maxAttempts=9} exhausted for failing-messages-0@28
```

Here are the relevant docs: https://docs.spring.io/spring-kafka/docs/3.0.12/reference/html/#default-eh

One way to get the behavior we want is to reconfigure ConcurrentKafkaListenerContainerFactor. We can use setCommonErrorHandler to configure it with a `DefaultErrorHandler` and we can set `FixedBackOff.UNLIMITED_ATTEMPTS`