### PR TITLE
Upgrade to Spring Boot 4.0.6 via spring-boot-dependencies BOM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A deliberately minimal Spring Boot service used for education and interviews. The entire application is two classes (`ExampleApplication`, `ExampleController`) exposing two endpoints. Keep changes small and self-contained unless asked otherwise.
+
+- `GET /` — returns `{"message": "Hello world!"}`
+- `POST /shutdown` — gracefully exits the JVM (spawns a thread that calls `SpringApplication.exit`)
+- Swagger UI at `/swagger-ui.html` (springdoc)
+- Server listens on port **1080** (`application.properties`)
+
+## Commands
+
+```bash
+mvn package              # compile + build the snapshot jar into target/
+mvn install              # also assembles the distributable into target/dist/ (see Deployment)
+mvn clean install        # full rebuild
+```
+
+There is **no test suite** — no `src/test`, no test dependencies, and no `spring-boot-maven-plugin`. If you add tests, you must also add the test dependencies (e.g. `spring-boot-starter-test`) to `pom.xml` first. Run a single test with `mvn test -Dtest=ClassName#method` only after that infrastructure exists.
+
+To run locally for manual checks, the simplest path is `mvn install` then the deployment run command below.
+
+## Deployment model (non-obvious)
+
+This project does **not** produce an executable fat jar. Instead:
+
+1. `mvn install` uses `maven-dependency-plugin` to copy all compile-scope dependencies into `target/dist/lib/`, copies the app jar there too, and `maven-resources-plugin` copies `application.properties`, `logback-spring.xml`, and `README.md` into `target/dist/`.
+2. Deploy by copying the contents of `target/dist/` to the server.
+3. Start with: `java -cp 'lib/*' com.zecops.example.ExampleApplication` (run from the dist directory).
+
+Logs are written to a `log/` folder relative to the working directory (`logback-spring.xml`, rolling daily/by-size, gzip).
+
+## Gotchas
+
+- **Package vs. owner mismatch**: the Java package and Maven `groupId` are `com.zecops`, but the repo is now owned by `jamf`/`crocodile` (CODEOWNERS, catalog-info.yaml). Renaming the package is a deliberate, separate effort — don't assume `com.zecops` is wrong.
+- **`pom.xml` is the source of truth for versions** — currently Spring Boot 4.0.6 (Spring Framework 7, Jackson 3), Java 17. Any `target/` artifacts may show stale versions from an older build; ignore them.
+- **Dependency versions come from the `spring-boot-dependencies` BOM** (imported in `<dependencyManagement>` with `<scope>import</scope>`), not the `spring-boot-starter-parent`. Don't add explicit `<version>` to anything the BOM manages (e.g. `spring-boot-starter-web`); only third-party deps the BOM doesn't cover need a version. `springdoc-openapi-starter-webmvc-ui` is one such — it's pinned to `3.0.3` because Spring Boot 4 requires springdoc 3.x (the old 2.x line is Boot 3 only).
+- The old explicit `snakeyaml` 2.2 override was removed in the Boot 4 upgrade — the BOM now manages a safe version (2.5), so let it.

--- a/pom.xml
+++ b/pom.xml
@@ -13,31 +13,32 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <service.name>spring-boot-example</service.name>
-        <spring.boot.version>3.1.5</spring.boot.version>
+        <spring.boot.version>4.0.6</spring.boot.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
+            <!-- Version managed by the spring-boot-dependencies BOM -->
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>${spring.boot.version}</version>
         </dependency>
         <dependency>
+            <!-- Third-party, not managed by the Spring Boot BOM; 3.x is required for Spring Boot 4 -->
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.2.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.datatype</groupId>
-                    <artifactId>jackson-datatype-jsr310</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <!-- Override the version brought by Spring which has a vulnerability -->
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>2.2</version>
+            <version>3.0.3</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## What

Upgrades the service to **Spring Boot 4.0.6** and switches dependency management to the **`spring-boot-dependencies` BOM** (imported in `<dependencyManagement>` with `<scope>import</scope>`, keeping the parent-less POM structure).

## Changes (`pom.xml`)

- `spring.boot.version` property `3.1.5` → `4.0.6` (brings Spring Framework 7 + Jackson 3).
- Import `spring-boot-dependencies:4.0.6` BOM; remove per-dependency version pinning where the BOM covers it.
- `spring-boot-starter-web`: drop explicit `<version>` (now BOM-managed).
- `springdoc-openapi-starter-webmvc-ui` `2.2.0` → `3.0.3` — Boot 4 requires the springdoc 3.x line; it's not in the BOM so it keeps an explicit version. Dropped the now-obsolete `jackson-datatype-jsr310` exclusion.
- Removed the manual `snakeyaml` 2.2 override — the BOM manages a safe version (resolves to 2.5).

## Notes

- **Java stays at 17** (Boot 4's minimum; Boot 4 supports up to Java 26).
- **Jackson 3** is now the default (new `tools.jackson` namespace). No impact on this minimal app; a Jackson 2 jar remains transitively via swagger-core, which is normal during the 2→3 transition.
- `CLAUDE.md` updated to document the BOM-based versioning and the removed snakeyaml override.

## Verification

- `mvn clean install` succeeds and assembles `target/dist/` with `spring-boot-4.0.6.jar`, `spring-boot-starter-web-4.0.6.jar`, `springdoc-openapi-*-3.0.3.jar`, `snakeyaml-2.5.jar`.
- Resolved tree confirms Spring Framework `7.0.7` and Jackson 3 (`tools.jackson.core:3.1.2`).
- Ran via `java -cp 'lib/*' com.zecops.example.ExampleApplication`: boots on **v4.0.6**, `GET /` → `{"message":"Hello world!"}`, springdoc `/v3/api-docs` → HTTP 200, `POST /shutdown` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)